### PR TITLE
모듈간의 의존성 테스트

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation project(':module-common') // root project -> settings.gradle에 선언한 값과 동일해야함.
 }
 
 tasks.named('test') {

--- a/module-api/settings.gradle
+++ b/module-api/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'module-api'


### PR DESCRIPTION
api모듈의 dependency에 implementation project 추가
settings.gradle을 먼저 읽기 때문에 제거

this closes #3 