### PR TITLE
Spring Multi Module을 IntelliJ가 아닌 Gradle을 사용해 빌드 및 배포

### DIFF
--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   jpa:
     database: mysql
     hibernate:
-      ddl-auto: none # or 'none'
+      ddl-auto: create # or 'none'
     properties:
       hibernate:
         format_sql: true

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -32,3 +32,11 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+tasks.bootJar { enabled = false }
+tasks.jar { enabled = true }
+
+// xxx.jar
+// xxx-plain.jar
+// java -jar xxx.jar
+
+// ./gradlew clean :module-api:buildNeeded --stacktrace --info --refresh-dependencies -x test


### PR DESCRIPTION
update: 프로젝트의 설계 단계이기 때문에 ddl은 create로 설정
feat: Gradle을 통해 빌드 및 배포을 위한 소스 추가

this closes #15 